### PR TITLE
Add tags to blogs and implement tag-based blog filtering

### DIFF
--- a/components/blog-post.tsx
+++ b/components/blog-post.tsx
@@ -1,5 +1,6 @@
 import { allImages } from '@/build/fixtures/images';
 import CommentSection from '@/components/giscus-comments';
+import { Badge } from "@/components/ui/badge";
 import {
     Popover,
     PopoverContent,
@@ -115,6 +116,13 @@ export function BlogPostHeader() {
                     })}
                 </time>
             </Date>
+            {frontMatter.tags && frontMatter.tags.length > 0 && (
+                <div className="flex flex-wrap gap-2 justify-center mt-4">
+                    {frontMatter.tags.map((tag: string) => (
+                        <Badge key={tag} variant="secondary">{tag}</Badge>
+                    ))}
+                </div>
+            )}
             <div className="w-full border-b border-gray-400 authors border-opacity-20">
                 <div className="flex justify-center mt-8 mb-2 mx-auto gap-14">
                     {authors && authors.length > 0 && (

--- a/components/blog-post.tsx
+++ b/components/blog-post.tsx
@@ -119,7 +119,9 @@ export function BlogPostHeader() {
             {frontMatter.tags && frontMatter.tags.length > 0 && (
                 <div className="flex flex-wrap gap-2 justify-center mt-4">
                     {frontMatter.tags.map((tag: string) => (
-                        <Badge key={tag} variant="secondary">{tag}</Badge>
+                        <Link href={`/blog?tag=${tag}`} key={tag} className="no-underline">
+                            <Badge variant="secondary">{tag}</Badge>
+                        </Link>
                     ))}
                 </div>
             )}

--- a/components/blog.tsx
+++ b/components/blog.tsx
@@ -168,7 +168,7 @@ export function BlogIndex() {
     return (
         <div className="pt-8 pb-16">
             {activeTag && (
-                <div className="flex items-center justify-between mb-8 py-2 px-4 bg-muted rounded-md">
+                <div className="flex items-center justify-between mb-8 py-2 px-4 bg-primary/10 dark:bg-primary/20 rounded-md">
                     <div className="flex items-center gap-2">
                         <span>Showing posts tagged: </span>
                         <Badge variant="secondary">{activeTag}</Badge>
@@ -178,7 +178,7 @@ export function BlogIndex() {
                     </Button>
                 </div>
             )}
-            <div className="grid gap-y-10 pt-8">{items}</div>
+            <div className="grid gap-y-10 pt-2">{items}</div>
         </div>
     )
 }

--- a/components/blog.tsx
+++ b/components/blog.tsx
@@ -126,16 +126,16 @@ export function BlogIndex() {
                                     </time>
                                 </p>
                             ) : null}
+                            {frontMatter.tags && frontMatter.tags.length > 0 && (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                                {frontMatter.tags.map((tag: string) => (
+                                <Badge key={tag} variant="secondary">{tag}</Badge>
+                                ))}
+                            </div>
+                            )}
                         </div>
                         <div className="hidden md:block ml-auto">{squareImageComponent}</div>
                     </div>
-                    {frontMatter.tags && frontMatter.tags.length > 0 && (
-                    <div className="mt-3 flex flex-wrap gap-2">
-                        {frontMatter.tags.map((tag: string) => (
-                            <Badge key={tag} variant="secondary">{tag}</Badge>
-                        ))}
-                    </div>
-                )}
                 </Link>
             </div>
         );

--- a/components/blog.tsx
+++ b/components/blog.tsx
@@ -44,11 +44,13 @@ export function BlogHeader() {
     );
 }
 
-export function BlogIndex() {
-    const router = useRouter();
-    const locale = router.locale || websiteConfig.default_locale;
-    const activeTag = router.query.tag as string | undefined;
 
+/**
+ * Gets all visible blog posts and filters them by tag if specified
+ * @param activeTag Optional tag to filter posts by
+ * @returns Array of filtered blog posts
+ */
+function getFilteredBlogPosts(activeTag?: string) {
     // Get all blog posts (excluding hidden ones)
     const allPosts = getPagesUnderRoute("/blog").filter((page) => {
         const frontMatter = (page as MdxFile).frontMatter || {};
@@ -64,6 +66,17 @@ export function BlogIndex() {
             return frontMatter.tags && frontMatter.tags.includes(activeTag);
         });
     }
+    
+    return filteredPosts;
+}
+
+export function BlogIndex() {
+    const router = useRouter();
+    const locale = router.locale || websiteConfig.default_locale;
+    const activeTag = router.query.tag as string | undefined;
+
+    // Get filtered blog posts
+    const filteredPosts = getFilteredBlogPosts(activeTag);
         
     const items = filteredPosts.map((page) => {
         const frontMatter = (page as MdxFile).frontMatter || {}

--- a/components/blog.tsx
+++ b/components/blog.tsx
@@ -44,12 +44,6 @@ export function BlogHeader() {
     );
 }
 
-
-/**
- * Gets all visible blog posts and filters them by tag if specified
- * @param activeTag Optional tag to filter posts by
- * @returns Array of filtered blog posts
- */
 function getFilteredBlogPosts(activeTag?: string) {
     // Get all blog posts (excluding hidden ones)
     const allPosts = getPagesUnderRoute("/blog").filter((page) => {
@@ -74,8 +68,6 @@ export function BlogIndex() {
     const router = useRouter();
     const locale = router.locale || websiteConfig.default_locale;
     const activeTag = router.query.tag as string | undefined;
-
-    // Get filtered blog posts
     const filteredPosts = getFilteredBlogPosts(activeTag);
         
     const items = filteredPosts.map((page) => {

--- a/components/blog.tsx
+++ b/components/blog.tsx
@@ -8,6 +8,7 @@ import {
     AlertDialogHeader,
     AlertDialogTitle
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import {
     Form,
     FormControl,
@@ -129,6 +130,13 @@ export function BlogIndex() {
                         <div className="hidden md:block ml-auto">{squareImageComponent}</div>
                     </div>
                 </Link>
+                {frontMatter.tags && frontMatter.tags.length > 0 && (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                        {frontMatter.tags.map((tag: string) => (
+                            <Badge key={tag} variant="secondary">{tag}</Badge>
+                        ))}
+                    </div>
+                )}
             </div>
         );
     })

--- a/components/blog.tsx
+++ b/components/blog.tsx
@@ -129,14 +129,14 @@ export function BlogIndex() {
                         </div>
                         <div className="hidden md:block ml-auto">{squareImageComponent}</div>
                     </div>
-                </Link>
-                {frontMatter.tags && frontMatter.tags.length > 0 && (
+                    {frontMatter.tags && frontMatter.tags.length > 0 && (
                     <div className="mt-3 flex flex-wrap gap-2">
                         {frontMatter.tags.map((tag: string) => (
                             <Badge key={tag} variant="secondary">{tag}</Badge>
                         ))}
                     </div>
                 )}
+                </Link>
             </div>
         );
     })

--- a/pages/blog/using-slurm-to-run-github-actions.mdx
+++ b/pages/blog/using-slurm-to-run-github-actions.mdx
@@ -15,8 +15,8 @@ reviewers:
 notify_subscribers: true
 hidden: false 
 tags:
-  - test2
-  - test3
+  - SLURM
+  - Infrastructure
 ---
 
 import { Cards } from 'nextra/components'

--- a/pages/blog/using-slurm-to-run-github-actions.mdx
+++ b/pages/blog/using-slurm-to-run-github-actions.mdx
@@ -14,6 +14,9 @@ reviewers:
   - ben
 notify_subscribers: true
 hidden: false 
+tags:
+  - test2
+  - test3
 ---
 
 import { Cards } from 'nextra/components'

--- a/pages/blog/vllm.mdx
+++ b/pages/blog/vllm.mdx
@@ -15,7 +15,9 @@ reviewers:
 notify_subscribers: true
 hidden: false
 tags:
-  - test1
+  - Guide
+  - LLMs
+  - SLURM
 ---
 
 import Picture from '@/components/picture'

--- a/pages/blog/vllm.mdx
+++ b/pages/blog/vllm.mdx
@@ -14,6 +14,8 @@ reviewers:
   - alexboden
 notify_subscribers: true
 hidden: false
+tags:
+  - test1
 ---
 
 import Picture from '@/components/picture'

--- a/pages/blog/what-is-watcloud.mdx
+++ b/pages/blog/what-is-watcloud.mdx
@@ -14,6 +14,9 @@ reviewers:
   - j257jian
 notify_subscribers: true
 hidden: false
+tags:
+  - test1
+  - test2
 ---
 
 WATcloud's mission is to make computing resources easily and fairly accessible to everyone.

--- a/pages/blog/what-is-watcloud.mdx
+++ b/pages/blog/what-is-watcloud.mdx
@@ -15,8 +15,8 @@ reviewers:
 notify_subscribers: true
 hidden: false
 tags:
-  - test1
-  - test2
+  - Infrastructure
+  - Guide
 ---
 
 WATcloud's mission is to make computing resources easily and fairly accessible to everyone.

--- a/pages/blog/what-is-watcloud.mdx
+++ b/pages/blog/what-is-watcloud.mdx
@@ -17,7 +17,6 @@ hidden: false
 tags:
   - Infrastructure
   - Guide
-  - test1
 ---
 
 WATcloud's mission is to make computing resources easily and fairly accessible to everyone.

--- a/pages/blog/what-is-watcloud.mdx
+++ b/pages/blog/what-is-watcloud.mdx
@@ -17,6 +17,7 @@ hidden: false
 tags:
   - Infrastructure
   - Guide
+  - test1
 ---
 
 WATcloud's mission is to make computing resources easily and fairly accessible to everyone.


### PR DESCRIPTION
This PR introduces tagging for the [blog page][bp]

- Display tags for each of the blog pages
- Implemented dynamic filtering by clickable tags
- Tag bar with dynamically updating tag counts

Resolves #44 

[bp]: https://cloud.watonomous.ca/blog
<img width="1498" height="1129" alt="image" src="https://github.com/user-attachments/assets/4d315bf4-3b71-4a96-8f59-a98403841d56" />
<img width="1497" height="1115" alt="image" src="https://github.com/user-attachments/assets/b858c771-0d61-47de-8d06-28c9d8af21e8" />


