### PR TITLE
Handle missing origin/data when generating fixtures

### DIFF
--- a/scripts/generate-fixtures.sh
+++ b/scripts/generate-fixtures.sh
@@ -66,6 +66,30 @@ if [ -n "$__fetch_from" ]; then
     wget --no-verbose -O "$PROJECT_DIR/build/fixtures/user-profiles.json" "$__fetch_from/user-profiles.json"
 else
     echo "Generating fixtures..."
+
+    # In shallow clones (e.g. `gh repo clone -- --depth 1`), or when cloning
+    # the public mirror — which does not contain the `data` branch — the
+    # `origin/data` ref may be missing locally. Try to fetch it on demand,
+    # and fall back to an actionable error if it is unavailable.
+    if ! git rev-parse --verify --quiet refs/remotes/origin/data >/dev/null; then
+        echo "origin/data not found locally; fetching..."
+        if ! git fetch --depth=1 origin data:refs/remotes/origin/data; then
+            cat >&2 <<EOF
+
+ERROR: Unable to find the 'data' branch on origin.
+
+The 'data' branch lives in the internal monorepo and is not mirrored to the
+public repo. To generate fixtures from a public source instead, re-run with
+FETCH_FIXTURES_FROM set (or pass --fetch-from). For example:
+
+    FETCH_FIXTURES_FROM=https://cloud.watonomous.ca/fixtures npm run generate-fixtures
+
+See README.md for details.
+EOF
+            exit 1
+        fi
+    fi
+
     # Create a new worktree
     git worktree add "$PROJECT_DIR/build/data" origin/data
     # Generate fixtures


### PR DESCRIPTION
Closes #49.

When running `npm run generate-fixtures` (invoked by `npm run dev`, `npm run build`, and `npm test`) in either a shallow clone (`gh repo clone -- --depth 1`) or any clone of the public mirror, the script previously failed with:

```
Generating fixtures...
fatal: invalid reference: origin/data
```

This PR makes `scripts/generate-fixtures.sh` check whether `origin/data` is available before calling `git worktree add`, attempt to fetch it on demand, and fall back to a clear, actionable error message that points the contributor at `FETCH_FIXTURES_FROM` when the ref isn't reachable.

### Behavior after change

| Environment | Before | After |
|---|---|---|
| Internal monorepo, full clone | works | works (no change) |
| Internal monorepo, shallow clone | `fatal: invalid reference: origin/data` | auto-fetches `origin/data`, then works |
| Public mirror, no env var | `fatal: invalid reference: origin/data` | clean actionable error pointing at `FETCH_FIXTURES_FROM` |
| Any clone, with `FETCH_FIXTURES_FROM` set | works | works (unrelated code path) |

### Testing

Verified locally on macOS:

1. Public mirror, no `FETCH_FIXTURES_FROM` → exits 1 with the new error message and git's underlying `fatal: couldn't find remote ref data` is preserved for debuggability.
2. Public mirror, `FETCH_FIXTURES_FROM=https://cloud.watonomous.ca/fixtures` → goes through the unchanged `wget` branch.
3. `bash -n scripts/generate-fixtures.sh` clean.

I do not have access to the internal monorepo, so I could not directly exercise the shallow-internal-clone case end-to-end — happy to defer to maintainers on that scenario.

### Scope notes

Intentionally kept the change focused. I did not touch `.github/workflows/build.yml` or make the data ref configurable via an env var — happy to extend if maintainers prefer.